### PR TITLE
Replace exists() with existsSync() because it is deprecated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "repository": "https://github.com/rackerlabs/atom-cloud-sync",
   "license": "Apache 2",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=0.180.0"
   },
   "dependencies": {
     "pkgcloud": ">=0.9.4",
     "underscore-plus": "1.x",
-    "pathwatcher": "1.2.1"
+    "pathwatcher": "3.3.1"
   }
 }

--- a/spec/sync-view-spec.coffee
+++ b/spec/sync-view-spec.coffee
@@ -146,7 +146,7 @@ describe 'SyncView', ->
 
         dir = new Directory(fullPathFor 'nodesc')
         sf = new File(fullPathFor 'nodesc', SYNCFILE)
-        expect(sf.exists()).toBe(true)
+        expect(sf.existsSync()).toBe(true)
 
         sd = null
         SyncDescription.createFrom sf, dir, (err, desc) ->


### PR DESCRIPTION
This deprecation was introduced in pathwatcher 3.3.0:
https://github.com/atom/node-pathwatcher/commit/6d6f2666dabe581111808a8cbe856d8429f0f21b

Atom started pulling in pathwatcher 3.3.1 in version 0.180.0:
https://github.com/atom/atom/commit/c260a29434547493d5f22508e2afd2da96f13f40